### PR TITLE
Fix eth_getLogs and other log rpc requets.

### DIFF
--- a/rpc/backend/utils.go
+++ b/rpc/backend/utils.go
@@ -293,6 +293,14 @@ func GetLogsFromBlockResults(blockRes *tmrpctypes.ResultBlockResults) ([][]*etht
 
 		blockLogs = append(blockLogs, logs...)
 	}
+
+	logs, err := AllTxLogsFromEvents(blockRes.EndBlockEvents)
+	if err != nil {
+		return nil, err
+	}
+
+	blockLogs = append(blockLogs, logs...)
+
 	return blockLogs, nil
 }
 


### PR DESCRIPTION
By default, ethermint does not discover omni deposit transactions in their rpc methods. This update allows any rpc call that uses GetLogsFromBlockResults to discover deposit transactions.

Also, most of our testing of rpc methods has been on an as needed, manual basis. We should start a running test suite of all the rpc methods. We can add this to omni monorepo, rather than here, as it it depends on deposit transactions. We should apply a deposit transaction, then run through all of the relevant rpc requests. 