### PR TITLE
Support EndBlock txns in trace tx.

### DIFF
--- a/rpc/backend/tracing.go
+++ b/rpc/backend/tracing.go
@@ -54,101 +54,59 @@ type traceType struct {
 // TraceTransaction returns the structured logs created during the execution of EVM
 // and returns them as a JSON object.
 func (b *Backend) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfig) (interface{}, error) {
-	// Get transaction by hash
-	transaction, endblock, err := b.GetTxByEthHash(hash)
+	transaction, _, err := b.GetTxByEthHash(hash)
 	if err != nil {
 		b.logger.Debug("tx not found", "hash", hash)
 		return nil, err
 	}
 
-	// TODO: see if we can make it work with cross chain txs
-	// check if tx is omni cross chain tx, if it is return dummy data
-	if endblock {
-		resBlock, err := b.TendermintBlockResultByNumber(&transaction.Height)
-		if err != nil {
-			b.logger.Debug("block result not found", "height", transaction.Height, "error", err.Error())
-			return nil, nil
-		}
-		txDetails, err := b.getTxDetailsFromEndBlockEvents(resBlock.EndBlockEvents, hash)
-		if err != nil {
-			b.logger.Debug("decoding failed", "error", err.Error())
-			return nil, fmt.Errorf("failed to decode tx from end block events: %w", err)
-		}
-		return traceType{
-			Calls:   []traceCalls{},
-			From:    common.HexToAddress(txDetails.TxMsg.From),
-			Gas:     "0x0",
-			GasUsed: "0x0",
-			Input:   "0x",
-			Output:  "0x",
-			To:      common.HexToAddress(txDetails.To),
-			Type:    "CALL",
-			Value:   "0x0",
-		}, nil
-	}
-
-	// check if block number is 0
-	if transaction.Height == 0 {
+	blockNum := rpctypes.BlockNumber(transaction.Height)
+	if blockNum == 0 {
 		return nil, errors.New("genesis is not traceable")
 	}
 
-	blk, err := b.TendermintBlockByNumber(rpctypes.BlockNumber(transaction.Height))
+	resBlock, err := b.TendermintBlockByNumber(blockNum)
 	if err != nil {
-		b.logger.Debug("block not found", "height", transaction.Height)
 		return nil, err
 	}
 
-	// check tx index is not out of bound
-	if uint32(len(blk.Block.Txs)) < transaction.TxIndex {
-		b.logger.Debug("tx index out of bounds", "index", transaction.TxIndex, "hash", hash.String(), "height", blk.Block.Height)
-		return nil, fmt.Errorf("transaction not included in block %v", blk.Block.Height)
+	if resBlock == nil {
+		// block not found
+		return nil, fmt.Errorf("block not found for height %d", blockNum)
 	}
+
+	blockRes, err := b.TendermintBlockResultByNumber(&resBlock.Block.Height)
+	if err != nil {
+		return nil, fmt.Errorf("block result not found for height %d", resBlock.Block.Height)
+	}
+
+	msgs := b.EthMsgsFromTendermintBlock(resBlock, blockRes)
+	endBlockMsgs := b.EthMsgsFromTendermintEndBlock(blockRes)
+	msgs = append(msgs, endBlockMsgs...)
 
 	var predecessors []*evmtypes.MsgEthereumTx
-	for _, txBz := range blk.Block.Txs[:transaction.TxIndex] {
-		tx, err := b.clientCtx.TxConfig.TxDecoder()(txBz)
-		if err != nil {
-			b.logger.Debug("failed to decode transaction in block", "height", blk.Block.Height, "error", err.Error())
-			continue
-		}
-		for _, msg := range tx.GetMsgs() {
-			ethMsg, ok := msg.(*evmtypes.MsgEthereumTx)
-			if !ok {
-				continue
-			}
-
-			predecessors = append(predecessors, ethMsg)
+	var msg *evmtypes.MsgEthereumTx
+	for _, m := range msgs {
+		if m.Hash == hash.Hex() {
+			msg = m
+			break
+		} else {
+			predecessors = append(predecessors, m)
 		}
 	}
 
-	tx, err := b.clientCtx.TxConfig.TxDecoder()(blk.Block.Txs[transaction.TxIndex])
-	if err != nil {
+	if msg == nil {
 		b.logger.Debug("tx not found", "hash", hash)
-		return nil, err
-	}
-
-	// add predecessor messages in current cosmos tx
-	for i := 0; i < int(transaction.MsgIndex); i++ {
-		ethMsg, ok := tx.GetMsgs()[i].(*evmtypes.MsgEthereumTx)
-		if !ok {
-			continue
-		}
-		predecessors = append(predecessors, ethMsg)
-	}
-
-	ethMessage, ok := tx.GetMsgs()[transaction.MsgIndex].(*evmtypes.MsgEthereumTx)
-	if !ok {
-		b.logger.Debug("invalid transaction type", "type", fmt.Sprintf("%T", tx))
-		return nil, fmt.Errorf("invalid transaction type %T", tx)
+		return nil, fmt.Errorf("tx not found in block %d", blockNum)
 	}
 
 	traceTxRequest := evmtypes.QueryTraceTxRequest{
-		Msg:             ethMessage,
+		Msg:             msg,
 		Predecessors:    predecessors,
-		BlockNumber:     blk.Block.Height,
-		BlockTime:       blk.Block.Time,
-		BlockHash:       common.Bytes2Hex(blk.BlockID.Hash),
-		ProposerAddress: sdk.ConsAddress(blk.Block.ProposerAddress),
+		BlockNumber:     resBlock.Block.Height,
+		BlockTime:       resBlock.Block.Time,
+		BlockHash:       common.Bytes2Hex(resBlock.BlockID.Hash),
+		ProposerAddress: sdk.ConsAddress(resBlock.Block.ProposerAddress),
 		ChainId:         b.chainID.Int64(),
 	}
 
@@ -162,9 +120,10 @@ func (b *Backend) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfi
 		// 0 is a special value in `ContextWithHeight`
 		contextHeight = 1
 	}
+
 	traceResult, err := b.queryClient.TraceTx(rpctypes.ContextWithHeight(contextHeight), &traceTxRequest)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to trace tx: %w", err)
 	}
 
 	// Response format is unknown due to custom tracer config param

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -421,12 +421,25 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to load evm config: %s", err.Error())
 	}
-	signer := ethtypes.MakeSigner(cfg.ChainConfig, big.NewInt(ctx.BlockHeight()))
 
 	txConfig := statedb.NewEmptyTxConfig(common.BytesToHash(ctx.HeaderHash().Bytes()))
 	for i, tx := range req.Predecessors {
+
 		ethTx := tx.AsTransaction()
-		msg, err := ethTx.AsMessage(signer, cfg.BaseFee)
+		msg := ethtypes.NewMessage(
+			common.HexToAddress(tx.From),
+			ethTx.To(),
+			ethTx.Nonce(),
+			ethTx.Value(),
+			ethTx.Gas(),
+			new(big.Int).Set(ethTx.GasPrice()),
+			new(big.Int).Set(ethTx.GasFeeCap()),
+			new(big.Int).Set(ethTx.GasTipCap()),
+			ethTx.Data(),
+			ethTx.AccessList(),
+			false, // isFake
+		)
+
 		if err != nil {
 			continue
 		}
@@ -451,7 +464,11 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 		_ = json.Unmarshal([]byte(req.TraceConfig.TracerJsonConfig), &tracerConfig)
 	}
 
-	result, _, err := k.traceTx(ctx, cfg, txConfig, signer, tx, req.TraceConfig, false, tracerConfig)
+	result, _, err := k.traceTx(
+		ctx, cfg, txConfig, common.HexToAddress(req.Msg.From), tx,
+		req.TraceConfig, false, tracerConfig,
+	)
+
 	if err != nil {
 		// error will be returned with detail status from traceTx
 		return nil, err
@@ -499,7 +516,6 @@ func (k Keeper) TraceBlock(c context.Context, req *types.QueryTraceBlockRequest)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "failed to load evm config")
 	}
-	signer := ethtypes.MakeSigner(cfg.ChainConfig, big.NewInt(ctx.BlockHeight()))
 	txsLength := len(req.Txs)
 	results := make([]*types.TxTraceResult, 0, txsLength)
 
@@ -509,7 +525,10 @@ func (k Keeper) TraceBlock(c context.Context, req *types.QueryTraceBlockRequest)
 		ethTx := tx.AsTransaction()
 		txConfig.TxHash = ethTx.Hash()
 		txConfig.TxIndex = uint(i)
-		traceResult, logIndex, err := k.traceTx(ctx, cfg, txConfig, signer, ethTx, req.TraceConfig, true, nil)
+		traceResult, logIndex, err := k.traceTx(
+			ctx, cfg, txConfig, common.HexToAddress(tx.From),
+			ethTx, req.TraceConfig, true, nil,
+		)
 		if err != nil {
 			result.Error = err.Error()
 		} else {
@@ -534,7 +553,7 @@ func (k *Keeper) traceTx(
 	ctx sdk.Context,
 	cfg *statedb.EVMConfig,
 	txConfig statedb.TxConfig,
-	signer ethtypes.Signer,
+	from common.Address,
 	tx *ethtypes.Transaction,
 	traceConfig *types.TraceConfig,
 	commitMessage bool,
@@ -547,7 +566,20 @@ func (k *Keeper) traceTx(
 		err       error
 		timeout   = defaultTraceTimeout
 	)
-	msg, err := tx.AsMessage(signer, cfg.BaseFee)
+	msg := ethtypes.NewMessage(
+		from,
+		tx.To(),
+		tx.Nonce(),
+		tx.Value(),
+		tx.Gas(),
+		new(big.Int).Set(tx.GasPrice()),
+		new(big.Int).Set(tx.GasFeeCap()),
+		new(big.Int).Set(tx.GasTipCap()),
+		tx.Data(),
+		tx.AccessList(),
+		false, // isFake
+	)
+
 	if err != nil {
 		return nil, 0, status.Error(codes.Internal, err.Error())
 	}


### PR DESCRIPTION
- include endblock txns in trace request contstruction, namely predecessors, when necessary
- rather than handle end block and regular tx separately, handle each with the same flow
- udpate TraceTx query to not very signatures of eth messages (which fails for EndBlock txns)

These changes fix `debug_traceTransaction` issues for end block txns. Which will allow our explorer to propoerly parse and display internal txns.