### PR TITLE
Respect fullTx param in getBlock-ers for endBlock txns

### DIFF
--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -445,9 +445,14 @@ func (b *Backend) RPCBlockFromTendermintBlock(
 		}
 		ethRPCTxs = append(ethRPCTxs, rpcTx)
 	}
-	rpcTxs := b.EthRPCTransactionsFromTendermintEndBlock(blockRes)
-	for _, rpcTx := range rpcTxs {
-		ethRPCTxs = append(ethRPCTxs, rpcTx)
+
+	endBlockRPCTxs := b.EthRPCTransactionsFromTendermintEndBlock(blockRes)
+	for _, tx := range endBlockRPCTxs {
+		if !fullTx {
+			ethRPCTxs = append(ethRPCTxs, tx.Hash)
+		} else {
+			ethRPCTxs = append(ethRPCTxs, tx)
+		}
 	}
 
 	bloom, err := b.BlockBloom(blockRes)


### PR DESCRIPTION
In eth_getBlockByNumber and eth_getBlockByHash, callers set a fullTx
bool param to decide if the full tx object, or just the tx hash, should
be included in the response. This param was respected for normal txns,
but not for endblock txns.

Tests added here https://github.com/omni-network/omni/pull/224