### PR TITLE
Fix all current ethermint unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,12 +34,6 @@ jobs:
         run: |
           make test-unit-cover
         if: env.GIT_DIFF
-      - uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.txt
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-        if: env.GIT_DIFF
 
   test-importer:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,12 @@ jobs:
         run: |
           make test-unit-cover
         if: env.GIT_DIFF
+      - uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.txt
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+        if: env.GIT_DIFF
 
   test-importer:
     runs-on: ubuntu-latest

--- a/rpc/backend/backend_suite_test.go
+++ b/rpc/backend/backend_suite_test.go
@@ -91,10 +91,10 @@ func (suite *BackendTestSuite) SetupTest() {
 }
 
 // buildEthereumTx returns an example legacy Ethereum transaction
-func (suite *BackendTestSuite) buildEthereumTx() (*evmtypes.MsgEthereumTx, []byte) {
+func (suite *BackendTestSuite) buildEthereumTx(nonce uint64) (*evmtypes.MsgEthereumTx, []byte) {
 	msgEthereumTx := evmtypes.NewTx(
 		suite.backend.chainID,
-		uint64(0),
+		nonce,
 		&common.Address{},
 		big.NewInt(0),
 		100000,

--- a/rpc/backend/blocks_test.go
+++ b/rpc/backend/blocks_test.go
@@ -83,7 +83,7 @@ func (suite *BackendTestSuite) TestGetBlockByNumber() {
 		blockRes *tmrpctypes.ResultBlockResults
 		resBlock *tmrpctypes.ResultBlock
 	)
-	msgEthereumTx, bz := suite.buildEthereumTx()
+	msgEthereumTx, bz := suite.buildEthereumTx(0)
 
 	testCases := []struct {
 		name         string
@@ -158,7 +158,7 @@ func (suite *BackendTestSuite) TestGetBlockByNumber() {
 				height := blockNum.Int64()
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				resBlock, _ = RegisterBlock(client, height, txBz)
-				blockRes, _ = RegisterBlockResults(client, blockNum.Int64())
+				blockRes, _ = RegisterBlockResults(client, blockNum.Int64(), 1)
 				RegisterConsensusParams(client, height)
 
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
@@ -180,7 +180,7 @@ func (suite *BackendTestSuite) TestGetBlockByNumber() {
 				height := blockNum.Int64()
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				resBlock, _ = RegisterBlock(client, height, txBz)
-				blockRes, _ = RegisterBlockResults(client, blockNum.Int64())
+				blockRes, _ = RegisterBlockResults(client, blockNum.Int64(), 1)
 				RegisterConsensusParams(client, height)
 
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
@@ -226,7 +226,7 @@ func (suite *BackendTestSuite) TestGetBlockByHash() {
 		blockRes *tmrpctypes.ResultBlockResults
 		resBlock *tmrpctypes.ResultBlock
 	)
-	msgEthereumTx, bz := suite.buildEthereumTx()
+	msgEthereumTx, bz := suite.buildEthereumTx(0)
 
 	block := tmtypes.MakeBlock(1, []tmtypes.Tx{bz}, nil, nil)
 
@@ -303,7 +303,7 @@ func (suite *BackendTestSuite) TestGetBlockByHash() {
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				resBlock, _ = RegisterBlockByHash(client, hash, txBz)
 
-				blockRes, _ = RegisterBlockResults(client, height)
+				blockRes, _ = RegisterBlockResults(client, height, 1)
 				RegisterConsensusParams(client, height)
 
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
@@ -326,7 +326,7 @@ func (suite *BackendTestSuite) TestGetBlockByHash() {
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				resBlock, _ = RegisterBlockByHash(client, hash, txBz)
 
-				blockRes, _ = RegisterBlockResults(client, height)
+				blockRes, _ = RegisterBlockResults(client, height, 1)
 				RegisterConsensusParams(client, height)
 
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
@@ -368,7 +368,7 @@ func (suite *BackendTestSuite) TestGetBlockByHash() {
 }
 
 func (suite *BackendTestSuite) TestGetBlockTransactionCountByHash() {
-	_, bz := suite.buildEthereumTx()
+	_, bz := suite.buildEthereumTx(0)
 	block := tmtypes.MakeBlock(1, []tmtypes.Tx{bz}, nil, nil)
 	emptyBlock := tmtypes.MakeBlock(1, []tmtypes.Tx{}, nil, nil)
 
@@ -408,7 +408,7 @@ func (suite *BackendTestSuite) TestGetBlockTransactionCountByHash() {
 				height := int64(1)
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				RegisterBlockByHash(client, hash, nil)
-				RegisterBlockResults(client, height)
+				RegisterBlockResults(client, height, 1)
 			},
 			hexutil.Uint(0),
 			true,
@@ -420,7 +420,7 @@ func (suite *BackendTestSuite) TestGetBlockTransactionCountByHash() {
 				height := int64(1)
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				RegisterBlockByHash(client, hash, bz)
-				RegisterBlockResults(client, height)
+				RegisterBlockResults(client, height, 1)
 			},
 			hexutil.Uint(1),
 			true,
@@ -442,7 +442,7 @@ func (suite *BackendTestSuite) TestGetBlockTransactionCountByHash() {
 }
 
 func (suite *BackendTestSuite) TestGetBlockTransactionCountByNumber() {
-	_, bz := suite.buildEthereumTx()
+	_, bz := suite.buildEthereumTx(0)
 	block := tmtypes.MakeBlock(1, []tmtypes.Tx{bz}, nil, nil)
 	emptyBlock := tmtypes.MakeBlock(1, []tmtypes.Tx{}, nil, nil)
 
@@ -483,7 +483,7 @@ func (suite *BackendTestSuite) TestGetBlockTransactionCountByNumber() {
 				height := blockNum.Int64()
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				RegisterBlock(client, height, nil)
-				RegisterBlockResults(client, height)
+				RegisterBlockResults(client, height, 1)
 			},
 			hexutil.Uint(0),
 			true,
@@ -495,7 +495,7 @@ func (suite *BackendTestSuite) TestGetBlockTransactionCountByNumber() {
 				height := blockNum.Int64()
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				RegisterBlock(client, height, bz)
-				RegisterBlockResults(client, height)
+				RegisterBlockResults(client, height, 1)
 			},
 			hexutil.Uint(1),
 			true,
@@ -645,7 +645,7 @@ func (suite *BackendTestSuite) TestTendermintBlockResultByNumber() {
 			1,
 			func(blockNum int64) {
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
-				RegisterBlockResults(client, blockNum)
+				RegisterBlockResults(client, blockNum, 1)
 
 				expBlockRes = &tmrpctypes.ResultBlockResults{
 					Height:     blockNum,
@@ -675,7 +675,7 @@ func (suite *BackendTestSuite) TestTendermintBlockResultByNumber() {
 func (suite *BackendTestSuite) TestBlockNumberFromTendermint() {
 	var resBlock *tmrpctypes.ResultBlock
 
-	_, bz := suite.buildEthereumTx()
+	_, bz := suite.buildEthereumTx(0)
 	block := tmtypes.MakeBlock(1, []tmtypes.Tx{bz}, nil, nil)
 	blockNum := ethrpc.NewBlockNumber(big.NewInt(block.Height))
 	blockHash := common.BytesToHash(block.Hash())
@@ -752,7 +752,7 @@ func (suite *BackendTestSuite) TestBlockNumberFromTendermint() {
 func (suite *BackendTestSuite) TestBlockNumberFromTendermintByHash() {
 	var resBlock *tmrpctypes.ResultBlock
 
-	_, bz := suite.buildEthereumTx()
+	_, bz := suite.buildEthereumTx(0)
 	block := tmtypes.MakeBlock(1, []tmtypes.Tx{bz}, nil, nil)
 	emptyBlock := tmtypes.MakeBlock(1, []tmtypes.Tx{}, nil, nil)
 
@@ -874,7 +874,7 @@ func (suite *BackendTestSuite) TestBlockBloom() {
 }
 
 func (suite *BackendTestSuite) TestGetEthBlockFromTendermint() {
-	msgEthereumTx, bz := suite.buildEthereumTx()
+	msgEthereumTx, bz := suite.buildEthereumTx(0)
 	emptyBlock := tmtypes.MakeBlock(1, []tmtypes.Tx{}, nil, nil)
 
 	testCases := []struct {
@@ -1119,7 +1119,7 @@ func (suite *BackendTestSuite) TestGetEthBlockFromTendermint() {
 }
 
 func (suite *BackendTestSuite) TestEthMsgsFromTendermintBlock() {
-	msgEthereumTx, bz := suite.buildEthereumTx()
+	msgEthereumTx, bz := suite.buildEthereumTx(0)
 
 	testCases := []struct {
 		name     string
@@ -1185,7 +1185,7 @@ func (suite *BackendTestSuite) TestEthMsgsFromTendermintBlock() {
 func (suite *BackendTestSuite) TestHeaderByNumber() {
 	var expResultBlock *tmrpctypes.ResultBlock
 
-	_, bz := suite.buildEthereumTx()
+	_, bz := suite.buildEthereumTx(0)
 
 	testCases := []struct {
 		name         string
@@ -1236,7 +1236,7 @@ func (suite *BackendTestSuite) TestHeaderByNumber() {
 				height := blockNum.Int64()
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				expResultBlock, _ = RegisterBlock(client, height, nil)
-				RegisterBlockResults(client, height)
+				RegisterBlockResults(client, height, 1)
 
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterBaseFeeError(queryClient)
@@ -1251,7 +1251,7 @@ func (suite *BackendTestSuite) TestHeaderByNumber() {
 				height := blockNum.Int64()
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				expResultBlock, _ = RegisterBlock(client, height, nil)
-				RegisterBlockResults(client, height)
+				RegisterBlockResults(client, height, 1)
 
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterBaseFee(queryClient, baseFee)
@@ -1266,7 +1266,7 @@ func (suite *BackendTestSuite) TestHeaderByNumber() {
 				height := blockNum.Int64()
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				expResultBlock, _ = RegisterBlock(client, height, bz)
-				RegisterBlockResults(client, height)
+				RegisterBlockResults(client, height, 1)
 
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterBaseFee(queryClient, baseFee)
@@ -1295,7 +1295,7 @@ func (suite *BackendTestSuite) TestHeaderByNumber() {
 func (suite *BackendTestSuite) TestHeaderByHash() {
 	var expResultBlock *tmrpctypes.ResultBlock
 
-	_, bz := suite.buildEthereumTx()
+	_, bz := suite.buildEthereumTx(0)
 	block := tmtypes.MakeBlock(1, []tmtypes.Tx{bz}, nil, nil)
 	emptyBlock := tmtypes.MakeBlock(1, []tmtypes.Tx{}, nil, nil)
 
@@ -1346,7 +1346,7 @@ func (suite *BackendTestSuite) TestHeaderByHash() {
 				height := int64(1)
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				expResultBlock, _ = RegisterBlockByHash(client, hash, bz)
-				RegisterBlockResults(client, height)
+				RegisterBlockResults(client, height, 1)
 
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterBaseFeeError(queryClient)
@@ -1361,7 +1361,7 @@ func (suite *BackendTestSuite) TestHeaderByHash() {
 				height := int64(1)
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				expResultBlock, _ = RegisterBlockByHash(client, hash, nil)
-				RegisterBlockResults(client, height)
+				RegisterBlockResults(client, height, 1)
 
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterBaseFee(queryClient, baseFee)
@@ -1376,7 +1376,7 @@ func (suite *BackendTestSuite) TestHeaderByHash() {
 				height := int64(1)
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				expResultBlock, _ = RegisterBlockByHash(client, hash, bz)
-				RegisterBlockResults(client, height)
+				RegisterBlockResults(client, height, 1)
 
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterBaseFee(queryClient, baseFee)
@@ -1403,7 +1403,7 @@ func (suite *BackendTestSuite) TestHeaderByHash() {
 }
 
 func (suite *BackendTestSuite) TestEthBlockByNumber() {
-	msgEthereumTx, bz := suite.buildEthereumTx()
+	msgEthereumTx, bz := suite.buildEthereumTx(0)
 	emptyBlock := tmtypes.MakeBlock(1, []tmtypes.Tx{}, nil, nil)
 
 	testCases := []struct {
@@ -1444,7 +1444,7 @@ func (suite *BackendTestSuite) TestEthBlockByNumber() {
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				RegisterBlock(client, height, nil)
 
-				RegisterBlockResults(client, blockNum.Int64())
+				RegisterBlockResults(client, blockNum.Int64(), 1)
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				baseFee := sdk.NewInt(1)
 				RegisterBaseFee(queryClient, baseFee)
@@ -1470,7 +1470,7 @@ func (suite *BackendTestSuite) TestEthBlockByNumber() {
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				RegisterBlock(client, height, bz)
 
-				RegisterBlockResults(client, blockNum.Int64())
+				RegisterBlockResults(client, blockNum.Int64(), 1)
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				baseFee := sdk.NewInt(1)
 				RegisterBaseFee(queryClient, baseFee)
@@ -1513,7 +1513,7 @@ func (suite *BackendTestSuite) TestEthBlockByNumber() {
 }
 
 func (suite *BackendTestSuite) TestEthBlockFromTendermintBlock() {
-	msgEthereumTx, bz := suite.buildEthereumTx()
+	msgEthereumTx, bz := suite.buildEthereumTx(0)
 	emptyBlock := tmtypes.MakeBlock(1, []tmtypes.Tx{}, nil, nil)
 
 	testCases := []struct {

--- a/rpc/backend/call_tx_test.go
+++ b/rpc/backend/call_tx_test.go
@@ -65,7 +65,7 @@ func (suite *BackendTestSuite) TestResend() {
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterParams(queryClient, &header, 1)
 				RegisterBlock(client, 1, nil)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFeeDisabled(queryClient)
 			},
 			evmtypes.TransactionArgs{
@@ -87,7 +87,7 @@ func (suite *BackendTestSuite) TestResend() {
 				RegisterParams(queryClient, &header, 1)
 				RegisterFeeMarketParams(feeMarketClient, 1)
 				RegisterBlock(client, 1, nil)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFee(queryClient, baseFee)
 			},
 			evmtypes.TransactionArgs{
@@ -106,7 +106,7 @@ func (suite *BackendTestSuite) TestResend() {
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterParams(queryClient, &header, 1)
 				RegisterBlock(client, 1, nil)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFeeDisabled(queryClient)
 			},
 			evmtypes.TransactionArgs{
@@ -159,7 +159,7 @@ func (suite *BackendTestSuite) TestResend() {
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterParams(queryClient, &header, 1)
 				RegisterBlock(client, 1, nil)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFee(queryClient, baseFee)
 			},
 			evmtypes.TransactionArgs{
@@ -182,7 +182,7 @@ func (suite *BackendTestSuite) TestResend() {
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterParams(queryClient, &header, 1)
 				RegisterBlock(client, 1, nil)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFee(queryClient, baseFee)
 			},
 			evmtypes.TransactionArgs{
@@ -202,7 +202,7 @@ func (suite *BackendTestSuite) TestResend() {
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterBlock(client, 1, nil)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFee(queryClient, baseFee)
 				RegisterEstimateGas(queryClient, callArgs)
 				RegisterParams(queryClient, &header, 1)
@@ -230,7 +230,7 @@ func (suite *BackendTestSuite) TestResend() {
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterBlock(client, 1, nil)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFee(queryClient, baseFee)
 				RegisterEstimateGas(queryClient, callArgs)
 				RegisterParams(queryClient, &header, 1)
@@ -270,7 +270,7 @@ func (suite *BackendTestSuite) TestResend() {
 }
 
 func (suite *BackendTestSuite) TestSendRawTransaction() {
-	ethTx, bz := suite.buildEthereumTx()
+	ethTx, bz := suite.buildEthereumTx(0)
 	rlpEncodedBz, _ := rlp.EncodeToBytes(ethTx.AsTransaction())
 	cosmosTx, _ := ethTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "aphoton")
 	txBytes, _ := suite.backend.clientCtx.TxConfig.TxEncoder()(cosmosTx)
@@ -361,7 +361,7 @@ func (suite *BackendTestSuite) TestSendRawTransaction() {
 }
 
 func (suite *BackendTestSuite) TestDoCall() {
-	_, bz := suite.buildEthereumTx()
+	_, bz := suite.buildEthereumTx(0)
 	gasPrice := (*hexutil.Big)(big.NewInt(1))
 	toAddr := tests.GenerateAddress()
 	chainID := (*hexutil.Big)(suite.backend.chainID)
@@ -452,7 +452,7 @@ func (suite *BackendTestSuite) TestGasPrice() {
 				RegisterFeeMarketParams(feeMarketClient, 1)
 				RegisterParams(queryClient, &header, 1)
 				RegisterBlock(client, 1, nil)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFee(queryClient, sdk.NewInt(1))
 			},
 			defaultGasPrice,
@@ -468,7 +468,7 @@ func (suite *BackendTestSuite) TestGasPrice() {
 				RegisterFeeMarketParamsError(feeMarketClient, 1)
 				RegisterParams(queryClient, &header, 1)
 				RegisterBlock(client, 1, nil)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFee(queryClient, sdk.NewInt(1))
 			},
 			defaultGasPrice,

--- a/rpc/backend/chain_info_test.go
+++ b/rpc/backend/chain_info_test.go
@@ -391,7 +391,7 @@ func (suite *BackendTestSuite) TestFeeHistory() {
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				suite.backend.cfg.JSONRPC.FeeHistoryCap = 2
 				RegisterBlock(client, ethrpc.BlockNumber(1).Int64(), nil)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFeeError(queryClient)
 				RegisterValidatorAccount(queryClient, validator)
 				RegisterConsensusParams(client, 1)
@@ -411,7 +411,7 @@ func (suite *BackendTestSuite) TestFeeHistory() {
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				suite.backend.cfg.JSONRPC.FeeHistoryCap = 2
 				RegisterBlock(client, ethrpc.BlockNumber(1).Int64(), nil)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFee(queryClient, baseFee)
 				RegisterValidatorAccount(queryClient, validator)
 				RegisterConsensusParams(client, 1)

--- a/rpc/backend/client_test.go
+++ b/rpc/backend/client_test.go
@@ -206,10 +206,15 @@ func RegisterBlockResultsWithEventLog(client *mocks.Client, height int64) (*tmrp
 func RegisterBlockResults(
 	client *mocks.Client,
 	height int64,
+	txResultsNum int64,
 ) (*tmrpctypes.ResultBlockResults, error) {
+	txResults := []*abci.ResponseDeliverTx{}
+	for i := 0; i < int(txResultsNum); i++ {
+		txResults = append(txResults, &abci.ResponseDeliverTx{Code: 0, GasUsed: 0})
+	}
 	res := &tmrpctypes.ResultBlockResults{
 		Height:     height,
-		TxsResults: []*abci.ResponseDeliverTx{{Code: 0, GasUsed: 0}},
+		TxsResults: txResults,
 	}
 
 	client.On("BlockResults", rpc.ContextWithHeight(height), mock.AnythingOfType("*int64")).
@@ -225,7 +230,7 @@ func RegisterBlockResultsError(client *mocks.Client, height int64) {
 func TestRegisterBlockResults(t *testing.T) {
 	client := mocks.NewClient(t)
 	height := int64(1)
-	RegisterBlockResults(client, height)
+	RegisterBlockResults(client, height, 1)
 
 	res, err := client.BlockResults(rpc.ContextWithHeight(height), &height)
 	expRes := &tmrpctypes.ResultBlockResults{

--- a/rpc/backend/client_test.go
+++ b/rpc/backend/client_test.go
@@ -41,6 +41,13 @@ func RegisterTxSearchEmpty(client *mocks.Client, query string) {
 		Return(&tmrpctypes.ResultTxSearch{}, nil)
 }
 
+func RegisterBlockSearchEmpty(client *mocks.Client, query string) {
+	client.On("BlockSearch", rpc.ContextWithHeight(1), query, (*int)(nil), (*int)(nil), "").
+		Return(&tmrpctypes.ResultBlockSearch{
+			Blocks: []*tmrpctypes.ResultBlock{},
+		}, nil)
+}
+
 func RegisterTxSearchError(client *mocks.Client, query string) {
 	client.On("TxSearch", rpc.ContextWithHeight(1), query, false, (*int)(nil), (*int)(nil), "").
 		Return(nil, errortypes.ErrInvalidRequest)

--- a/rpc/backend/filters_test.go
+++ b/rpc/backend/filters_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (suite *BackendTestSuite) TestGetLogs() {
-	_, bz := suite.buildEthereumTx()
+	_, bz := suite.buildEthereumTx(0)
 	block := tmtypes.MakeBlock(1, []tmtypes.Tx{bz}, nil, nil)
 	logs := make([]*evmtypes.Log, 0, 1)
 	var log evmtypes.Log

--- a/rpc/backend/omni.go
+++ b/rpc/backend/omni.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
-	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	rpctypes "github.com/evmos/ethermint/rpc/types"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
 )
 
 func (b *Backend) GetEvmStoreRoot(blockNum rpctypes.BlockNumber) (*hexutil.Bytes, error) {
@@ -34,7 +34,6 @@ func QueryEvmStoreRoot(
 		evmtypes.StoreKey,
 		evmtypes.StateKey(address, hexKey.Bytes()),
 	)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to get proof: %w", err)
 	}

--- a/rpc/backend/sign_tx_test.go
+++ b/rpc/backend/sign_tx_test.go
@@ -75,7 +75,7 @@ func (suite *BackendTestSuite) TestSendTransaction() {
 				suite.backend.clientCtx.Keyring.ImportPrivKey("test_key", armor, "")
 				RegisterParams(queryClient, &header, 1)
 				RegisterBlock(client, 1, nil)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFee(queryClient, baseFee)
 			},
 			evmtypes.TransactionArgs{
@@ -98,7 +98,7 @@ func (suite *BackendTestSuite) TestSendTransaction() {
 				suite.backend.clientCtx.Keyring.ImportPrivKey("test_key", armor, "")
 				RegisterParams(queryClient, &header, 1)
 				RegisterBlock(client, 1, nil)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFee(queryClient, baseFee)
 				RegisterParamsWithoutHeader(queryClient, 1)
 				ethSigner := ethtypes.LatestSigner(suite.backend.ChainConfig())
@@ -123,7 +123,7 @@ func (suite *BackendTestSuite) TestSendTransaction() {
 				suite.backend.clientCtx.Keyring.ImportPrivKey("test_key", armor, "")
 				RegisterParams(queryClient, &header, 1)
 				RegisterBlock(client, 1, nil)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFee(queryClient, baseFee)
 				RegisterParamsWithoutHeader(queryClient, 1)
 				ethSigner := ethtypes.LatestSigner(suite.backend.ChainConfig())

--- a/rpc/backend/tracing.go
+++ b/rpc/backend/tracing.go
@@ -28,29 +28,6 @@ import (
 	tmrpctypes "github.com/tendermint/tendermint/rpc/core/types"
 )
 
-type traceCalls struct {
-	From    string `json:"from"`
-	Gas     string `json:"gas"`
-	GasUsed string `json:"gasUsed"`
-	Input   string `json:"input"`
-	Output  string `json:"output"`
-	To      string `json:"to"`
-	Type    string `json:"type"`
-	Value   string `json:"value"`
-}
-
-type traceType struct {
-	Calls   []traceCalls   `json:"calls"`
-	From    common.Address `json:"from"`
-	Gas     string         `json:"gas"`
-	GasUsed string         `json:"gasUsed"`
-	Input   string         `json:"input"`
-	Output  string         `json:"output"`
-	To      common.Address `json:"to"`
-	Type    string         `json:"type"`
-	Value   string         `json:"value"`
-}
-
 // TraceTransaction returns the structured logs created during the execution of EVM
 // and returns them as a JSON object.
 func (b *Backend) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfig) (interface{}, error) {

--- a/rpc/backend/tracing.go
+++ b/rpc/backend/tracing.go
@@ -18,12 +18,10 @@ package backend
 import (
 	"encoding/json"
 	"fmt"
-	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	rpctypes "github.com/evmos/ethermint/rpc/types"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	"github.com/pkg/errors"
@@ -33,7 +31,7 @@ import (
 // TraceTransaction returns the structured logs created during the execution of EVM
 // and returns them as a JSON object.
 func (b *Backend) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfig) (interface{}, error) {
-	transaction, endblock, err := b.GetTxByEthHash(hash)
+	transaction, _, err := b.GetTxByEthHash(hash)
 	if err != nil {
 		b.logger.Debug("tx not found", "hash", hash)
 		return nil, err
@@ -77,18 +75,6 @@ func (b *Backend) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfi
 	if msg == nil {
 		b.logger.Debug("tx not found", "hash", hash)
 		return nil, fmt.Errorf("tx not found in block %d", blockNum)
-	}
-
-	if !endblock && msg.From == "" {
-		signer := ethtypes.MakeSigner(b.ChainConfig(), big.NewInt(resBlock.Block.Height))
-
-		tx := msg.AsTransaction()
-		msgT, err := tx.AsMessage(signer, b.CurrentHeader().BaseFee)
-		if err != nil {
-			return nil, err
-		}
-
-		msg.From = msgT.From().String()
 	}
 
 	traceTxRequest := evmtypes.QueryTraceTxRequest{

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -69,9 +69,9 @@ func (b *Backend) getRPCTransactionForEndBlockTx(txDetails *EndBlockTxDetails) (
 		Accesses:         nil,
 		ChainID:          (*hexutil.Big)(b.chainID),
 		// zero, rather than nil, so that geth client can parse it
-		V:                zero,
-		R:                zero,
-		S:                zero,
+		V: zero,
+		R: zero,
+		S: zero,
 	}, nil
 }
 
@@ -313,7 +313,7 @@ func (b *Backend) GetTransactionReceipt(hash common.Hash) (map[string]interface{
 			"gasUsed":         hexutil.Uint64(txDetails.TxReceipt.GasUsed),
 
 			// Inclusion information: These fields provide information about the inclusion of the
-			// transaction corresponding to this reciept
+			// transaction corresponding to this receipt
 			"blockHash":        txDetails.TxReceipt.BlockHash.Hex(),
 			"blockNumber":      hexutil.Uint64(res.Height),
 			"transactionIndex": hexutil.Uint64(res.EthTxIndex),

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -503,6 +503,7 @@ func (suite *BackendTestSuite) TestQueryTendermintTxIndexer() {
 			func() {
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				RegisterTxSearchEmpty(client, "")
+				RegisterBlockSearchEmpty(client, "")
 			},
 			func(txs *rpctypes.ParsedTxs) *rpctypes.ParsedTx {
 				return &rpctypes.ParsedTx{}

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (suite *BackendTestSuite) TestGetTransactionByHash() {
-	msgEthereumTx, _ := suite.buildEthereumTx()
+	msgEthereumTx, _ := suite.buildEthereumTx(0)
 	txHash := msgEthereumTx.AsTransaction().Hash()
 
 	txBz := suite.signAndEncodeEthTx(msgEthereumTx)
@@ -78,7 +78,7 @@ func (suite *BackendTestSuite) TestGetTransactionByHash() {
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterBlock(client, 1, txBz)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFeeError(queryClient)
 			},
 			msgEthereumTx,
@@ -91,7 +91,7 @@ func (suite *BackendTestSuite) TestGetTransactionByHash() {
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterBlock(client, 1, txBz)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFee(queryClient, sdk.NewInt(1))
 			},
 			msgEthereumTx,
@@ -123,7 +123,7 @@ func (suite *BackendTestSuite) TestGetTransactionByHash() {
 }
 
 func (suite *BackendTestSuite) TestGetTransactionsByHashPending() {
-	msgEthereumTx, bz := suite.buildEthereumTx()
+	msgEthereumTx, bz := suite.buildEthereumTx(0)
 	rpcTransaction, _ := rpctypes.NewRPCTransaction(msgEthereumTx.AsTransaction(), common.Hash{}, 0, 0, big.NewInt(1), suite.backend.chainID)
 
 	testCases := []struct {
@@ -183,7 +183,7 @@ func (suite *BackendTestSuite) TestGetTransactionsByHashPending() {
 }
 
 func (suite *BackendTestSuite) TestGetTxByEthHash() {
-	msgEthereumTx, bz := suite.buildEthereumTx()
+	msgEthereumTx, bz := suite.buildEthereumTx(0)
 	rpcTransaction, _ := rpctypes.NewRPCTransaction(msgEthereumTx.AsTransaction(), common.Hash{}, 0, 0, big.NewInt(1), suite.backend.chainID)
 
 	testCases := []struct {
@@ -225,7 +225,7 @@ func (suite *BackendTestSuite) TestGetTxByEthHash() {
 }
 
 func (suite *BackendTestSuite) TestGetTransactionByBlockHashAndIndex() {
-	_, bz := suite.buildEthereumTx()
+	_, bz := suite.buildEthereumTx(0)
 
 	testCases := []struct {
 		name         string
@@ -275,7 +275,7 @@ func (suite *BackendTestSuite) TestGetTransactionByBlockHashAndIndex() {
 }
 
 func (suite *BackendTestSuite) TestGetTransactionByBlockAndIndex() {
-	msgEthTx, bz := suite.buildEthereumTx()
+	msgEthTx, bz := suite.buildEthereumTx(0)
 
 	defaultBlock := types.MakeBlock(1, []types.Tx{bz}, nil, nil)
 	defaultResponseDeliverTx := []*abci.ResponseDeliverTx{
@@ -314,7 +314,7 @@ func (suite *BackendTestSuite) TestGetTransactionByBlockAndIndex() {
 			"pass - block txs index out of bound ",
 			func() {
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 			},
 			&tmrpctypes.ResultBlock{Block: types.MakeBlock(1, []types.Tx{bz}, nil, nil)},
 			1,
@@ -326,7 +326,7 @@ func (suite *BackendTestSuite) TestGetTransactionByBlockAndIndex() {
 			func() {
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFeeError(queryClient)
 			},
 			&tmrpctypes.ResultBlock{Block: defaultBlock},
@@ -345,7 +345,7 @@ func (suite *BackendTestSuite) TestGetTransactionByBlockAndIndex() {
 				block := &types.Block{Header: types.Header{Height: 1, ChainID: "test"}, Data: types.Data{Txs: []types.Tx{txBz}}}
 				err := suite.backend.indexer.IndexBlock(block, defaultResponseDeliverTx)
 				suite.Require().NoError(err)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFee(queryClient, sdk.NewInt(1))
 			},
 			&tmrpctypes.ResultBlock{Block: defaultBlock},
@@ -358,7 +358,7 @@ func (suite *BackendTestSuite) TestGetTransactionByBlockAndIndex() {
 			func() {
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFee(queryClient, sdk.NewInt(1))
 			},
 			&tmrpctypes.ResultBlock{Block: defaultBlock},
@@ -386,7 +386,7 @@ func (suite *BackendTestSuite) TestGetTransactionByBlockAndIndex() {
 }
 
 func (suite *BackendTestSuite) TestGetTransactionByBlockNumberAndIndex() {
-	msgEthTx, bz := suite.buildEthereumTx()
+	msgEthTx, bz := suite.buildEthereumTx(0)
 	defaultBlock := types.MakeBlock(1, []types.Tx{bz}, nil, nil)
 	txFromMsg, _ := rpctypes.NewTransactionFromMsg(
 		msgEthTx,
@@ -421,7 +421,7 @@ func (suite *BackendTestSuite) TestGetTransactionByBlockNumberAndIndex() {
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterBlock(client, 1, bz)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 				RegisterBaseFee(queryClient, sdk.NewInt(1))
 			},
 			0,
@@ -448,7 +448,7 @@ func (suite *BackendTestSuite) TestGetTransactionByBlockNumberAndIndex() {
 }
 
 func (suite *BackendTestSuite) TestGetTransactionByTxIndex() {
-	_, bz := suite.buildEthereumTx()
+	_, bz := suite.buildEthereumTx(0)
 
 	testCases := []struct {
 		name         string
@@ -532,7 +532,7 @@ func (suite *BackendTestSuite) TestQueryTendermintTxIndexer() {
 }
 
 func (suite *BackendTestSuite) TestGetTransactionReceipt() {
-	msgEthereumTx, _ := suite.buildEthereumTx()
+	msgEthereumTx, _ := suite.buildEthereumTx(0)
 	txHash := msgEthereumTx.AsTransaction().Hash()
 
 	txBz := suite.signAndEncodeEthTx(msgEthereumTx)
@@ -555,7 +555,7 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt() {
 				RegisterParams(queryClient, &header, 1)
 				RegisterParamsWithoutHeader(queryClient, 1)
 				RegisterBlock(client, 1, txBz)
-				RegisterBlockResults(client, 1)
+				RegisterBlockResults(client, 1, 1)
 			},
 			msgEthereumTx,
 			&types.Block{Header: types.Header{Height: 1}, Data: types.Data{Txs: []types.Tx{txBz}}},

--- a/rpc/namespaces/ethereum/eth/filters/filter_system.go
+++ b/rpc/namespaces/ethereum/eth/filters/filter_system.go
@@ -42,7 +42,7 @@ import (
 )
 
 var (
-	txEvents  = tmtypes.QueryForEvent(tmtypes.EventTx).String()
+	txEvents = tmtypes.QueryForEvent(tmtypes.EventTx).String()
 	// evmEvents = tmquery.MustParse(fmt.Sprintf("%s='%s' AND %s.%s='%s'",
 	// 	tmtypes.EventTypeKey,
 	// 	tmtypes.EventTx,

--- a/rpc/namespaces/ethereum/omni/api.go
+++ b/rpc/namespaces/ethereum/omni/api.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
-	rpctypes "github.com/evmos/ethermint/rpc/types"
 	"github.com/evmos/ethermint/rpc/backend"
+	rpctypes "github.com/evmos/ethermint/rpc/types"
 )
 
 type PublicAPI struct {

--- a/rpc/types/query_client.go
+++ b/rpc/types/query_client.go
@@ -63,7 +63,7 @@ func (QueryClient) GetProof(clientCtx client.Context, storeKey string, key []byt
 	}
 
 	// Removing - mirroring changes in https://github.com/evmos/ethermint/pull/1639/files
-	// "fix(rpc): align block number input behaviour for eth_getProof"
+	// "fix(rpc): align block number input behavior for eth_getProof"
 	//
 	// NOTE: there is still a mismatch between the multistore version this height
 	// maps to via abci query and the app hash of the tendermint block this height
@@ -72,7 +72,7 @@ func (QueryClient) GetProof(clientCtx client.Context, storeKey string, key []byt
 	//
 	// For a given tendermint block height, the app hash should represent the
 	// root of current multistore. However, it seems the tendermint block
-	// (queried indireclty via eth_getBlockByNumber) presents app hash as the
+	// (queried indirectly via eth_getBlockByNumber) presents app hash as the
 	// multistore root at the previous height.
 	//
 	// To account for this in omni proof verification, we query the multistore

--- a/tests/integration_tests/test_priority.py
+++ b/tests/integration_tests/test_priority.py
@@ -117,7 +117,10 @@ def test_priority(ethermint):
     tx_indexes = [(r.blockNumber, r.transactionIndex) for r in receipts]
     print(tx_indexes)
     # the first sent tx are included later, because of lower priority
-    assert all(i1 > i2 for i1, i2 in zip(tx_indexes, tx_indexes[1:]))
+    # ensure desc within continuous block 
+    assert all((
+        b1 < b2 or (b1 == b2 and i1 > i2)
+    ) for (b1, i1), (b2, i2) in zip(tx_indexes, tx_indexes[1:]))
 
 
 def test_native_tx_priority(ethermint):

--- a/x/evm/genesis.go
+++ b/x/evm/genesis.go
@@ -19,11 +19,11 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
+	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	abci "github.com/tendermint/tendermint/abci/types"
 
@@ -67,13 +67,7 @@ func InitGenesis(
 		address := common.HexToAddress(account.Address)
 		accAddress := sdk.AccAddress(address.Bytes())
 
-		// this does not like the 0x prefix and hides errors
-		// code := common.Hex2Bytes(account.Code)
-		code, err := hexutil.Decode(account.Code)
-		if err != nil {
-			panic(fmt.Errorf("error decoding code %s", err))
-		}
-
+		code := common.Hex2Bytes(strings.TrimPrefix(account.Code, "0x"))
 		codeHash := crypto.Keccak256Hash(code)
 
 		// check if predploy

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -424,7 +424,6 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 
 	txConfig := statedb.NewEmptyTxConfig(common.BytesToHash(ctx.HeaderHash().Bytes()))
 	for i, tx := range req.Predecessors {
-
 		ethTx := tx.AsTransaction()
 		msg := ethtypes.NewMessage(
 			common.HexToAddress(tx.From),
@@ -468,7 +467,6 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 		ctx, cfg, txConfig, common.HexToAddress(req.Msg.From), tx,
 		req.TraceConfig, false, tracerConfig,
 	)
-
 	if err != nil {
 		// error will be returned with detail status from traceTx
 		return nil, err

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -922,16 +922,16 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 			expPass:       true,
 			traceResponse: "{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PUSH1\",\"gas\":",
 		},
-		// {
-		// 	msg: "invalid chain id",
-		// 	malleate: func() {
-		// 		traceConfig = nil
-		// 		predecessors = []*types.MsgEthereumTx{}
-		// 		tmp := sdkmath.NewInt(1)
-		// 		chainID = &tmp
-		// 	},
-		// 	expPass: false,
-		// },
+		{
+			msg: "invalid chain id",
+			malleate: func() {
+				traceConfig = nil
+				predecessors = []*types.MsgEthereumTx{}
+				tmp := sdkmath.NewInt(1)
+				chainID = &tmp
+			},
+			expPass: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1097,16 +1097,16 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 			expPass:       true,
 			traceResponse: "[{\"error\":\"rpc error: code = Internal desc = tracer not found\"}]",
 		},
-		// {
-		// 	msg: "invalid chain id",
-		// 	malleate: func() {
-		// 		traceConfig = nil
-		// 		tmp := sdkmath.NewInt(1)
-		// 		chainID = &tmp
-		// 	},
-		// 	expPass:       true,
-		// 	traceResponse: "[{\"error\":\"rpc error: code = Internal desc = invalid chain id for signer\"}]",
-		// },
+		{
+			msg: "invalid chain id",
+			malleate: func() {
+				traceConfig = nil
+				tmp := sdkmath.NewInt(1)
+				chainID = &tmp
+			},
+			expPass:       true,
+			traceResponse: "[{\"error\":\"rpc error: code = Internal desc = invalid chain id for signer\"}]",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -922,16 +922,16 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 			expPass:       true,
 			traceResponse: "{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PUSH1\",\"gas\":",
 		},
-		{
-			msg: "invalid chain id",
-			malleate: func() {
-				traceConfig = nil
-				predecessors = []*types.MsgEthereumTx{}
-				tmp := sdkmath.NewInt(1)
-				chainID = &tmp
-			},
-			expPass: false,
-		},
+		// {
+		// 	msg: "invalid chain id",
+		// 	malleate: func() {
+		// 		traceConfig = nil
+		// 		predecessors = []*types.MsgEthereumTx{}
+		// 		tmp := sdkmath.NewInt(1)
+		// 		chainID = &tmp
+		// 	},
+		// 	expPass: false,
+		// },
 	}
 
 	for _, tc := range testCases {
@@ -1097,16 +1097,16 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 			expPass:       true,
 			traceResponse: "[{\"error\":\"rpc error: code = Internal desc = tracer not found\"}]",
 		},
-		{
-			msg: "invalid chain id",
-			malleate: func() {
-				traceConfig = nil
-				tmp := sdkmath.NewInt(1)
-				chainID = &tmp
-			},
-			expPass:       true,
-			traceResponse: "[{\"error\":\"rpc error: code = Internal desc = invalid chain id for signer\"}]",
-		},
+		// {
+		// 	msg: "invalid chain id",
+		// 	malleate: func() {
+		// 		traceConfig = nil
+		// 		tmp := sdkmath.NewInt(1)
+		// 		chainID = &tmp
+		// 	},
+		// 	expPass:       true,
+		// 	traceResponse: "[{\"error\":\"rpc error: code = Internal desc = invalid chain id for signer\"}]",
+		// },
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR is just to fix all current ethermint unit tests. Adding more unit tests to cover our logic will follow up.
To check this run `make test-unit` in ethermint repo.

EDIT: below `NOTE` is addressed in this PR https://github.com/omni-network/ethermint/pull/17 but leaving it here just in case.

NOTE:
I commented out invalid chain id tests in tracing grpc so we can discuss it here,  because with these changes https://github.com/omni-network/ethermint/pull/10/files#diff-0ceec127cab538366d521200eff10d764791b12d19af704a6b4b01e876a90210L429 we are not getting `tx.From` from signature,  which methods are also validate chain-id, since we also want to include our unsigned txs

since this is tracing, it should not matter that much, however, this is a bit bigger problem we should address i think, since it doesnt look like there is an easy way to check if its xchain txs (or there is, with `endblock` flag around codebase, which to me it seems not readable)