### PR TITLE
Fix integration tests pt1

### DIFF
--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -92,6 +92,9 @@ schema = 3
   [mod."github.com/confio/ics23/go"]
     version = "v0.9.0"
     hash = "sha256-guD8w7YygfUp7lpTAUyXQuCPx8F3lXkcg+yR5+JOCbk="
+  [mod."github.com/cosmos/ics23/go"]
+    version = "v0.10.0"
+    hash = "sha256-KYEv727BO/ht63JO02xiKFGFAddg41Ve9l2vSSZZBq0="
   [mod."github.com/cosmos/btcutil"]
     version = "v1.0.5"
     hash = "sha256-t572Sr5iiHcuMKLMWa2i+LBAt192oa+G1oA371tG/eI="

--- a/rpc/backend/tracing.go
+++ b/rpc/backend/tracing.go
@@ -18,10 +18,12 @@ package backend
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	rpctypes "github.com/evmos/ethermint/rpc/types"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	"github.com/pkg/errors"
@@ -54,7 +56,7 @@ type traceType struct {
 // TraceTransaction returns the structured logs created during the execution of EVM
 // and returns them as a JSON object.
 func (b *Backend) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfig) (interface{}, error) {
-	transaction, _, err := b.GetTxByEthHash(hash)
+	transaction, endblock, err := b.GetTxByEthHash(hash)
 	if err != nil {
 		b.logger.Debug("tx not found", "hash", hash)
 		return nil, err
@@ -98,6 +100,18 @@ func (b *Backend) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfi
 	if msg == nil {
 		b.logger.Debug("tx not found", "hash", hash)
 		return nil, fmt.Errorf("tx not found in block %d", blockNum)
+	}
+
+	if !endblock {
+		signer := ethtypes.MakeSigner(b.ChainConfig(), big.NewInt(resBlock.Block.Height))
+
+		tx := msg.AsTransaction()
+		msgT, err := tx.AsMessage(signer, b.CurrentHeader().BaseFee)
+		if err != nil {
+			return nil, err
+		}
+
+		msg.From = msgT.From().String()
 	}
 
 	traceTxRequest := evmtypes.QueryTraceTxRequest{

--- a/rpc/backend/tracing.go
+++ b/rpc/backend/tracing.go
@@ -102,7 +102,7 @@ func (b *Backend) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfi
 		return nil, fmt.Errorf("tx not found in block %d", blockNum)
 	}
 
-	if !endblock {
+	if !endblock && msg.From == "" {
 		signer := ethtypes.MakeSigner(b.ChainConfig(), big.NewInt(resBlock.Block.Height))
 
 		tx := msg.AsTransaction()


### PR DESCRIPTION
First part of fixing integration tests.

debug_traceTransaction integration rpc test for non-xchain tx is failing (returning empty tx with empty fields), it turned out msg.From is empty

msg.From is derived from signer, and we removed that here https://github.com/omni-network/ethermint/pull/10/files#r1332081047  because we want to also trace unsigned transactions

i added a "fix" just to start discussion if i am on right track here, and if we should somehow better distinguish xchain and non-xchain transactions through ethermint repo